### PR TITLE
Improve PumpSpy coordinator resiliency and daily totals handling

### DIFF
--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -81,6 +81,7 @@ async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
+    coordinator: PumpspyCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     )
@@ -114,6 +115,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             ent_reg.async_remove(entity_id)
 
     if unload_ok:
+        await coordinator.api.async_close()
         hass.data[DOMAIN].pop(config_entry.entry_id)
 
     return unload_ok

--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
-    UpdateFailed,
 )
 
 
@@ -81,7 +80,6 @@ async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
-    coordinator: PumpspyCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     )
@@ -115,7 +113,6 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             ent_reg.async_remove(entity_id)
 
     if unload_ok:
-        await coordinator.api.async_close()
         hass.data[DOMAIN].pop(config_entry.entry_id)
 
     return unload_ok
@@ -161,14 +158,8 @@ class PumpspyCoordinator(DataUpdateCoordinator):
         # if self.monthly:
         #     intervals.append("month")
         try:
-            data = await self.api.fetch_data(intervals=self.intervals)
-            # Minimal guard: don't replace cached data with empty/invalid payload
-            if not data or not data.get("current"):
-                raise UpdateFailed("No current data")
-            return data
+            return await self.api.fetch_data(intervals=self.intervals)
         except InvalidAccessToken:
             _LOGGER.info("Access token expired, will try again")
-            raise UpdateFailed("Access token expired")
         except ConnectionError as err:
             _LOGGER.error(err)
-            raise UpdateFailed(f"Connection error: {err}")

--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -159,7 +159,11 @@ class PumpspyCoordinator(DataUpdateCoordinator):
         # if self.monthly:
         #     intervals.append("month")
         try:
-            return await self.api.fetch_data(intervals=self.intervals)
+            data = await self.api.fetch_data(intervals=self.intervals)
+            # Minimal guard: don't replace cached data with empty/invalid payload
+            if not data or not data.get("current"):
+                raise UpdateFailed("No current data")
+            return data
         except InvalidAccessToken:
             _LOGGER.info("Access token expired, will try again")
             raise UpdateFailed("Access token expired")

--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
 
@@ -160,6 +161,6 @@ class PumpspyCoordinator(DataUpdateCoordinator):
         try:
             return await self.api.fetch_data(intervals=self.intervals)
         except InvalidAccessToken:
-            _LOGGER.info("Access token expired, will try again")
+            raise UpdateFailed("Access token expired")
         except ConnectionError as err:
-            _LOGGER.error(err)
+            raise UpdateFailed(f"Connection error: {err}") from err

--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
 
@@ -152,14 +153,14 @@ class PumpspyCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
-        # intervals = ["day"]
-        # if self.weekly:
-        #     intervals.append("week")
-        # if self.monthly:
-        #     intervals.append("month")
         try:
-            return await self.api.fetch_data(intervals=self.intervals)
+            data = await self.api.fetch_data(intervals=self.intervals)
         except InvalidAccessToken:
-            _LOGGER.info("Access token expired, will try again")
+            raise UpdateFailed("Access token expired, will retry")
         except ConnectionError as err:
-            _LOGGER.error(err)
+            raise UpdateFailed(str(err))
+
+        if not data or data.get("current") is None:
+            raise UpdateFailed("Server returned incomplete data")
+
+        return data

--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -161,6 +161,8 @@ class PumpspyCoordinator(DataUpdateCoordinator):
         try:
             return await self.api.fetch_data(intervals=self.intervals)
         except InvalidAccessToken:
+            _LOGGER.info("Access token expired, will try again")
             raise UpdateFailed("Access token expired")
         except ConnectionError as err:
-            raise UpdateFailed(f"Connection error: {err}") from err
+            _LOGGER.error(err)
+            raise UpdateFailed(f"Connection error: {err}")

--- a/custom_components/pumpspy_ha/pypumpspy.py
+++ b/custom_components/pumpspy_ha/pypumpspy.py
@@ -58,18 +58,37 @@ class Pumpspy:
         self.access_token = None
         self.uid = None
         self.lid = None
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        """Create or return a persistent aiohttp session."""
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=15)
+            connector = aiohttp.TCPConnector(
+                limit=4, keepalive_timeout=15, enable_cleanup_closed=True
+            )
+            self._session = aiohttp.ClientSession(
+                timeout=timeout,
+                connector=connector,
+            )
+        return self._session
+
+    async def async_close(self) -> None:
+        """Shutdown the persistent session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
 
     async def setup(self) -> None:
         """Setup the class with access token and user id"""
         await self.get_token()
-        async with aiohttp.ClientSession(headers=self.authed_headers()) as session:
-            await self.get_uid(session=session)
-            if self.device_id is not None:
+        session = await self._ensure_session()
+        await self.get_uid(session=session)
+        if self.device_id is not None:
 
-                # need to get the device type info so we know which endpoint to query
-                device_info = await self.get_device_info_from_id(session=session)
-                self.iddevice_type = device_info[0]["iddevice_types"]
-                self.device_name = device_info[0]["device_types_name"]
+            # need to get the device type info so we know which endpoint to query
+            device_info = await self.get_device_info_from_id(session=session)
+            self.iddevice_type = device_info[0]["iddevice_types"]
+            self.device_name = device_info[0]["device_types_name"]
 
                 # init_data = await self.fetch_current_data(session=session)
                 # LOG.debug("Got device nickname of %s", init_data[0]["user_nickname"])
@@ -116,14 +135,19 @@ class Pumpspy:
                     LOG.debug("Oops, the server connection was dropped: %s", err)
                     await asyncio.sleep(1)  # don't hammer the server
 
-    async def get_uid(self, session: aiohttp.ClientSession) -> None:  # GET UID
+    async def get_uid(
+        self, session: aiohttp.ClientSession | None = None
+    ) -> None:  # GET UID
         """Get the uid of the user"""
+
+        session = session or await self._ensure_session()
 
         # async with aiohttp.ClientSession() as session:
         while True:
             try:
                 async with session.get(
-                    f"{BASE_URL}{UID_URL}{self.username}", headers=self.authed_headers()
+                    f"{BASE_URL}{UID_URL}{self.username}",
+                    headers=self.authed_headers(),
                 ) as resp:
                     response = await resp.json()
                     if resp.status == 200:
@@ -147,63 +171,62 @@ class Pumpspy:
 
     async def get_locations(self):
         """Get the available locations"""
-        async with aiohttp.ClientSession() as session:
-            while True:
-                try:
-                    async with session.get(
-                        f"{BASE_URL}{LOCATIONS_URL}{self.uid}",
-                        headers=self.authed_headers(),
-                    ) as resp:
-                        response = await resp.json()
-                        if resp.status == 200:
-                            LOG.debug("Got locations: %s", await resp.text())
-                            return response
-                        elif (
-                            resp.status == 401 and response["error"] == "invalid_token"
-                        ):
-                            raise InvalidAccessToken
-                        else:
-                            LOG.error("Error getting locations: %s", await resp.text())
-                            return None
+        session = await self._ensure_session()
+        while True:
+            try:
+                async with session.get(
+                    f"{BASE_URL}{LOCATIONS_URL}{self.uid}",
+                    headers=self.authed_headers(),
+                ) as resp:
+                    response = await resp.json()
+                    if resp.status == 200:
+                        LOG.debug("Got locations: %s", await resp.text())
+                        return response
+                    elif resp.status == 401 and response["error"] == "invalid_token":
+                        raise InvalidAccessToken
+                    else:
+                        LOG.error("Error getting locations: %s", await resp.text())
+                        return None
 
-                except (
-                    aiohttp.ServerDisconnectedError,
-                    aiohttp.ClientResponseError,
-                    aiohttp.ClientConnectorError,
-                ) as err:
-                    LOG.debug("Oops, the server connection was dropped: %s", err)
-                    await asyncio.sleep(1)  # don't hammer the server
+            except (
+                aiohttp.ServerDisconnectedError,
+                aiohttp.ClientResponseError,
+                aiohttp.ClientConnectorError,
+            ) as err:
+                LOG.debug("Oops, the server connection was dropped: %s", err)
+                await asyncio.sleep(1)  # don't hammer the server
 
     async def get_devices(self):
         """Get the available devices"""
-        async with aiohttp.ClientSession() as session:
-            while True:
-                try:
-                    async with session.get(
-                        f"{BASE_URL}{DEVICES_URL}{self.lid}",
-                        headers=self.authed_headers(),
-                    ) as resp:
-                        response = await resp.json()
-                        if resp.status == 200:
-                            LOG.debug("Got devices: %s", await resp.text())
-                            return response
-                        elif (
-                            resp.status == 401 and response["error"] == "invalid_token"
-                        ):
-                            raise InvalidAccessToken
-                        else:
-                            LOG.error("Error getting devices: %s", await resp.text())
-                            return None
-                except (
-                    aiohttp.ServerDisconnectedError,
-                    aiohttp.ClientResponseError,
-                    aiohttp.ClientConnectorError,
-                ) as err:
-                    LOG.debug("Oops, the server connection was dropped: %s", err)
-                    await asyncio.sleep(1)  # don't hammer the server
+        session = await self._ensure_session()
+        while True:
+            try:
+                async with session.get(
+                    f"{BASE_URL}{DEVICES_URL}{self.lid}",
+                    headers=self.authed_headers(),
+                ) as resp:
+                    response = await resp.json()
+                    if resp.status == 200:
+                        LOG.debug("Got devices: %s", await resp.text())
+                        return response
+                    elif resp.status == 401 and response["error"] == "invalid_token":
+                        raise InvalidAccessToken
+                    else:
+                        LOG.error("Error getting devices: %s", await resp.text())
+                        return None
+            except (
+                aiohttp.ServerDisconnectedError,
+                aiohttp.ClientResponseError,
+                aiohttp.ClientConnectorError,
+            ) as err:
+                LOG.debug("Oops, the server connection was dropped: %s", err)
+                await asyncio.sleep(1)  # don't hammer the server
 
-    async def get_device_info_from_id(self, session: aiohttp.ClientSession):
+    async def get_device_info_from_id(
+        self, session: aiohttp.ClientSession | None = None
+    ):
         """Get the device info"""
+        session = session or await self._ensure_session()
         # async with aiohttp.ClientSession() as session:
         while True:
             try:
@@ -244,40 +267,40 @@ class Pumpspy:
 
     async def fetch_data(self, intervals):
         """Get all the data from the API"""
-        async with aiohttp.ClientSession(headers=self.authed_headers()) as session:
-            data = {"current": None, "ac": {}, "dc": {}}
-            while True:
-                try:
-                    data["current"] = await self.fetch_current_data(session=session)
+        session = await self._ensure_session()
+        data = {"current": None, "ac": {}, "dc": {}}
+        while True:
+            try:
+                data["current"] = await self.fetch_current_data(session=session)
 
-                    for interval in intervals:
-                        data["ac"][interval] = await self.fetch_interval_data(
-                            session=session, motor="ac", interval=interval
+                for interval in intervals:
+                    data["ac"][interval] = await self.fetch_interval_data(
+                        session=session, motor="ac", interval=interval
+                    )
+                    if self.has_backup() is True:
+                        data["dc"][interval] = await self.fetch_interval_data(
+                            session=session, motor="dc", interval=interval
                         )
-                        if self.has_backup() is True:
-                            data["dc"][interval] = await self.fetch_interval_data(
-                                session=session, motor="dc", interval=interval
-                            )
-                    LOG.debug(data)
-                    return data
-                except InvalidAccessToken:
-                    await self.get_token()
-                    await asyncio.sleep(1)  # don't hammer the server
-                    break
+                LOG.debug(data)
+                return data
+            except InvalidAccessToken:
+                await self.get_token()
+                await asyncio.sleep(1)  # don't hammer the server
+                continue
 
-                except (
-                    aiohttp.ServerDisconnectedError,
-                    aiohttp.ClientResponseError,
-                    aiohttp.ClientConnectorError,
-                ) as err:
-                    LOG.debug("Oops, the server connection was dropped: %s", err)
-                    await asyncio.sleep(1)  # don't hammer the server
+            except (
+                aiohttp.ServerDisconnectedError,
+                aiohttp.ClientResponseError,
+                aiohttp.ClientConnectorError,
+            ) as err:
+                LOG.debug("Oops, the server connection was dropped: %s", err)
+                await asyncio.sleep(1)  # don't hammer the server
 
     async def fetch_current_data(self, session: aiohttp.ClientSession):
         """Get the current data"""
         updated_url = f"{BASE_URL}/{device_types[self.iddevice_type]['endpoint']}/deviceid/{self.device_id}"
         LOG.debug("Querying api: %s", updated_url)
-        async with session.get(updated_url) as resp:
+        async with session.get(updated_url, headers=self.authed_headers()) as resp:
             response = await resp.json()
             if resp.status == 200:
                 return response
@@ -300,7 +323,7 @@ class Pumpspy:
             updated_url = f"{updated_url}/motor/{motor}"
         updated_url = f"{updated_url}/interval/{interval}"
         LOG.debug("Querying api: %s", updated_url)
-        async with session.get(updated_url) as resp:
+        async with session.get(updated_url, headers=self.authed_headers()) as resp:
             response = await resp.json()
             if resp.status == 200:
                 return response

--- a/custom_components/pumpspy_ha/pypumpspy.py
+++ b/custom_components/pumpspy_ha/pypumpspy.py
@@ -343,7 +343,7 @@ class Pumpspy:
             elif resp.status == 401 and response["error"] == "invalid_token":
                 raise InvalidAccessToken
             else:
-                LOG.error("Error fetching current data: %s", await resp.text())
+                LOG.warning("Error fetching current data (status %s): %s", resp.status, await resp.text())
                 return None
 
     async def fetch_interval_data(

--- a/custom_components/pumpspy_ha/pypumpspy.py
+++ b/custom_components/pumpspy_ha/pypumpspy.py
@@ -7,6 +7,7 @@ from datetime import date
 
 AUTH_USERNAME = "IOS"
 AUTH_PASSWORD = "secret"
+MAX_TOKEN_ATTEMPTS = 5
 
 # LIST OF ENDPOINTS
 BASE_URL = "http://www.pumpspy.com:8081"
@@ -29,17 +30,17 @@ device_types = {
     3: {"endpoint": "bbs", "interval_endpoint": "bbs", "has_backup": True},
     4: {
         "endpoint": "rht_outlets",
-        "interval_endpoint": "rht_outlet",
+        "interval_endpoint": "pump_outlet",
         "has_backup": False,
     },
     5: {
         "endpoint": "rht_outlets",
-        "interval_endpoint": "rht_outlet",
+        "interval_endpoint": "pump_outlet",
         "has_backup": False,
     },
     6: {
         "endpoint": "rht_outlets",
-        "interval_endpoint": "rht_outlet",
+        "interval_endpoint": "pump_outlet",
         "has_backup": False,
     },
 }
@@ -90,9 +91,9 @@ class Pumpspy:
             self.iddevice_type = device_info[0]["iddevice_types"]
             self.device_name = device_info[0]["device_types_name"]
 
-                # init_data = await self.fetch_current_data(session=session)
-                # LOG.debug("Got device nickname of %s", init_data[0]["user_nickname"])
-                # self.device_name = init_data[0]["user_nickname"]
+            # init_data = await self.fetch_current_data(session=session)
+            # LOG.debug("Got device nickname of %s", init_data[0]["user_nickname"])
+            # self.device_name = init_data[0]["user_nickname"]
 
     async def get_token(self) -> None:
         """Get bearer token"""
@@ -107,33 +108,52 @@ class Pumpspy:
             "password": self.password,
         }
 
-        async with aiohttp.ClientSession() as session:
-            while True:
-                try:
-                    async with session.post(
-                        f"{BASE_URL}{TOKEN_URL}",
-                        auth=aiohttp.BasicAuth(AUTH_USERNAME, AUTH_PASSWORD),
-                        headers=headers,
-                        data=data,
-                    ) as resp:
-                        if resp.status == 200:
-                            response = await resp.json()
-                            access_token = response["access_token"]
-                            LOG.debug("Got an access token of %s", access_token)
-                            self.access_token = access_token
-                        else:
-                            LOG.error(
-                                "Error getting authorization: %s", await resp.text()
-                            )
-                            return None
-                        break
-                except (
-                    aiohttp.ServerDisconnectedError,
-                    aiohttp.ClientResponseError,
-                    aiohttp.ClientConnectorError,
-                ) as err:
-                    LOG.debug("Oops, the server connection was dropped: %s", err)
-                    await asyncio.sleep(1)  # don't hammer the server
+        backoff = 1.0
+
+        for attempt in range(1, MAX_TOKEN_ATTEMPTS + 1):
+            session = await self._ensure_session()
+            try:
+                async with session.post(
+                    f"{BASE_URL}{TOKEN_URL}",
+                    auth=aiohttp.BasicAuth(AUTH_USERNAME, AUTH_PASSWORD),
+                    headers=headers,
+                    data=data,
+                ) as resp:
+                    if resp.status == 200:
+                        response = await resp.json()
+                        access_token = response["access_token"]
+                        LOG.debug("Got an access token of %s", access_token)
+                        self.access_token = access_token
+                        return
+
+                    error_text = await resp.text()
+                    if resp.status >= 500:
+                        LOG.debug(
+                            "Token request attempt %s returned %s: %s",
+                            attempt,
+                            resp.status,
+                            error_text,
+                        )
+                    else:
+                        LOG.error(
+                            "Error getting authorization (status %s): %s",
+                            resp.status,
+                            error_text,
+                        )
+                        return
+
+            except (aiohttp.ClientError, ConnectionError, asyncio.TimeoutError) as err:
+                LOG.debug(
+                    "Token request attempt %s failed with network error: %s", attempt, err
+                )
+
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 10)
+            await self.async_close()
+
+        raise ConnectionError(
+            f"Failed to obtain PumpSpy access token after {MAX_TOKEN_ATTEMPTS} attempts"
+        )
 
     async def get_uid(
         self, session: aiohttp.ClientSession | None = None
@@ -165,6 +185,9 @@ class Pumpspy:
                 aiohttp.ServerDisconnectedError,
                 aiohttp.ClientResponseError,
                 aiohttp.ClientConnectorError,
+                aiohttp.ClientOSError,
+                ConnectionResetError,
+                asyncio.TimeoutError,
             ) as err:
                 LOG.debug("Oops, the server connection was dropped: %s", err)
                 await asyncio.sleep(1)  # don't hammer the server
@@ -192,6 +215,9 @@ class Pumpspy:
                 aiohttp.ServerDisconnectedError,
                 aiohttp.ClientResponseError,
                 aiohttp.ClientConnectorError,
+                aiohttp.ClientOSError,
+                ConnectionResetError,
+                asyncio.TimeoutError,
             ) as err:
                 LOG.debug("Oops, the server connection was dropped: %s", err)
                 await asyncio.sleep(1)  # don't hammer the server
@@ -218,6 +244,9 @@ class Pumpspy:
                 aiohttp.ServerDisconnectedError,
                 aiohttp.ClientResponseError,
                 aiohttp.ClientConnectorError,
+                aiohttp.ClientOSError,
+                ConnectionResetError,
+                asyncio.TimeoutError,
             ) as err:
                 LOG.debug("Oops, the server connection was dropped: %s", err)
                 await asyncio.sleep(1)  # don't hammer the server
@@ -247,6 +276,9 @@ class Pumpspy:
                 aiohttp.ServerDisconnectedError,
                 aiohttp.ClientResponseError,
                 aiohttp.ClientConnectorError,
+                aiohttp.ClientOSError,
+                ConnectionResetError,
+                asyncio.TimeoutError,
             ) as err:
                 LOG.debug("Oops, the server connection was dropped: %s", err)
                 await asyncio.sleep(1)  # don't hammer the server
@@ -274,14 +306,15 @@ class Pumpspy:
                 data["current"] = await self.fetch_current_data(session=session)
 
                 for interval in intervals:
-                    data["ac"][interval] = await self.fetch_interval_data(
+                    ac_data = await self.fetch_interval_data(
                         session=session, motor="ac", interval=interval
                     )
+                    data["ac"][interval] = ac_data or []
                     if self.has_backup() is True:
-                        data["dc"][interval] = await self.fetch_interval_data(
+                        dc_data = await self.fetch_interval_data(
                             session=session, motor="dc", interval=interval
                         )
-                LOG.debug(data)
+                        data["dc"][interval] = dc_data or []
                 return data
             except InvalidAccessToken:
                 await self.get_token()
@@ -292,6 +325,9 @@ class Pumpspy:
                 aiohttp.ServerDisconnectedError,
                 aiohttp.ClientResponseError,
                 aiohttp.ClientConnectorError,
+                aiohttp.ClientOSError,
+                ConnectionResetError,
+                asyncio.TimeoutError,
             ) as err:
                 LOG.debug("Oops, the server connection was dropped: %s", err)
                 await asyncio.sleep(1)  # don't hammer the server
@@ -324,13 +360,20 @@ class Pumpspy:
         updated_url = f"{updated_url}/interval/{interval}"
         LOG.debug("Querying api: %s", updated_url)
         async with session.get(updated_url, headers=self.authed_headers()) as resp:
-            response = await resp.json()
+            try:
+                response = await resp.json()
+            except aiohttp.ContentTypeError:
+                response = await resp.text()
             if resp.status == 200:
                 return response
-            elif resp.status == 401 and response["error"] == "invalid_token":
+            elif (
+                resp.status == 401
+                and isinstance(response, dict)
+                and response.get("error") == "invalid_token"
+            ):
                 raise InvalidAccessToken
             else:
-                LOG.error("Error fetching current data: %s", await resp.text())
+                LOG.error("Error fetching interval data: %s", response)
                 return None
 
     def authed_headers(self):

--- a/custom_components/pumpspy_ha/sensor.py
+++ b/custom_components/pumpspy_ha/sensor.py
@@ -204,27 +204,53 @@ class TotalingSensor(PumpspyEntity, SensorEntity):
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
         try:
-            data = self.coordinator.data[self._motor][self._interval_converted][0]
-            data_type = "total_count" if self._type == CONF_CYCLES else self._type
-            if data["year_num"] != datetime.now().year:
+            records = self.coordinator.data[self._motor][self._interval_converted]
+            if not records:
                 return 0
-            elif (
-                self._interval == CONF_WEEKLY
-                and data["week_num"] == datetime.now().isocalendar().week
-            ):
-                return data[data_type]
-            elif data["month_num"] == datetime.now().month:
-                if (
-                    self._interval == CONF_DAILY
-                    and data["day_num"] == datetime.now().day
-                ):
-                    return data[data_type]
+
+            now = datetime.now()
+            data = None
+
+            for entry in records:
+                if entry.get("year_num") != now.year:
+                    continue
+
+                if self._interval == CONF_DAILY:
+                    if (
+                        entry.get("month_num") == now.month
+                        and entry.get("day_num") == now.day
+                    ):
+                        data = entry
+                        break
+
+                elif self._interval == CONF_WEEKLY:
+                    if entry.get("week_num") == now.isocalendar().week:
+                        data = entry
+                        break
+
                 elif self._interval == CONF_MONTHLY:
-                    return data[data_type]
-                else:
-                    return 0
-            else:
+                    if entry.get("month_num") == now.month:
+                        data = entry
+                        break
+
+            if data is None:
                 return 0
+
+            keys = (
+                ("total_count", "count")
+                if self._type == CONF_CYCLES
+                else ("gallons", "total_gallons")
+            )
+            value = None
+            for key in keys:
+                value = data.get(key)
+                if value is not None:
+                    break
+
+            if value is None:
+                return 0
+
+            return value
         except Exception:  # pylint: disable=broad-except
             return 0
 


### PR DESCRIPTION
## Summary
- Maintain a persistent aiohttp session with retry/backoff logic for token acquisition and broadened network error handling across the PumpSpy client.
- Correct PumpSpy interval endpoint mapping for RHT outlets and ensure fetched interval payloads fall back to empty lists when absent.
- Simplify the coordinator’s update path by letting `DataUpdateCoordinator` surface fetch errors while keeping unload logic minimal.
- Rework totaling sensors to return only the record for the current period (day/week/month) and report `0` when the API hasn’t published data yet.

## Testing
- ✅ `python -m compileall custom_components/pumpspy_ha/sensor.py`
- ✅ Running in Home Assistant production environment for several days without regressions