### PR TITLE
Fix 6 critical bugs: unique_id, auth, location selection, token retry, coordinator, device IDs

### DIFF
--- a/custom_components/pumpspy_ha/__init__.py
+++ b/custom_components/pumpspy_ha/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
 
@@ -152,14 +153,9 @@ class PumpspyCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
-        # intervals = ["day"]
-        # if self.weekly:
-        #     intervals.append("week")
-        # if self.monthly:
-        #     intervals.append("month")
         try:
             return await self.api.fetch_data(intervals=self.intervals)
-        except InvalidAccessToken:
-            _LOGGER.info("Access token expired, will try again")
+        except InvalidAccessToken as err:
+            raise UpdateFailed("Access token expired and could not be refreshed") from err
         except ConnectionError as err:
-            _LOGGER.error(err)
+            raise UpdateFailed(f"Connection error: {err}") from err

--- a/custom_components/pumpspy_ha/config_flow.py
+++ b/custom_components/pumpspy_ha/config_flow.py
@@ -7,7 +7,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.core import callback
-from .pypumpspy import Pumpspy
+from .pypumpspy import InvalidAccessToken, Pumpspy
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
@@ -50,12 +50,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.pumpspy = Pumpspy(
                 username=user_input[CONF_USERNAME], password=user_input[CONF_PASSWORD]
             )
-            await self.pumpspy.setup()
-            self.data[CONF_USERNAME] = user_input[CONF_USERNAME]
-            self.data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
-            self.locations = await self.pumpspy.get_locations()
-            if self.locations:
-                return await self.async_step_location()
+            try:
+                await self.pumpspy.setup()
+            except (InvalidAccessToken, Exception) as err:
+                _LOGGER.error("Error authenticating with Pumpspy: %s", err)
+                errors["base"] = "auth"
+            else:
+                self.data[CONF_USERNAME] = user_input[CONF_USERNAME]
+                self.data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+                self.locations = await self.pumpspy.get_locations()
+                if self.locations:
+                    return await self.async_step_location()
+                else:
+                    errors["base"] = "no_locations"
 
         data_schema = vol.Schema(
             {
@@ -81,7 +88,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_device()
 
         if user_input is not None:
-            self.pumpspy.set_location(self.locations[0]["lid"])
+            self.pumpspy.set_location(int(user_input["location"]))
             self.devices = await self.pumpspy.get_devices()
             if self.devices:
                 return await self.async_step_device()
@@ -114,7 +121,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # skip this step if there is only 1 device
         if len(self.devices) == 1:
             self.data[CONF_DEVICEID] = self.devices[0]["deviceid"]
-            await self.async_set_unique_id(self.devices[0]["deviceid"])
+            await self.async_set_unique_id(str(self.devices[0]["deviceid"]))
             self._abort_if_unique_id_configured()
             self.device_name = self.devices[0]["device_types_name"]
             return await self.async_step_sensors()

--- a/custom_components/pumpspy_ha/entity.py
+++ b/custom_components/pumpspy_ha/entity.py
@@ -19,7 +19,7 @@ class PumpspyEntity(CoordinatorEntity[PumpspyCoordinator]):
     def device_info(self) -> DeviceInfo | None:
         try:
             return DeviceInfo(
-                identifiers={(DOMAIN, self.coordinator.data["current"][0]["deviceid"])},
+                identifiers={(DOMAIN, str(self.coordinator.data["current"][0]["deviceid"]))},
                 name=self.coordinator.data["current"][0]["user_nickname"],
                 manufacturer=MANUFACTURER,
                 model=self.coordinator.data["current"][0]["device_types_name"],

--- a/custom_components/pumpspy_ha/manifest.json
+++ b/custom_components/pumpspy_ha/manifest.json
@@ -13,5 +13,5 @@
     "@Crewski"
   ],
   "iot_class": "cloud_polling",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/custom_components/pumpspy_ha/pypumpspy.py
+++ b/custom_components/pumpspy_ha/pypumpspy.py
@@ -244,10 +244,12 @@ class Pumpspy:
 
     async def fetch_data(self, intervals):
         """Get all the data from the API"""
-        async with aiohttp.ClientSession(headers=self.authed_headers()) as session:
-            data = {"current": None, "ac": {}, "dc": {}}
-            while True:
+        retries = 0
+        max_retries = 2
+        while retries < max_retries:
+            async with aiohttp.ClientSession(headers=self.authed_headers()) as session:
                 try:
+                    data = {"current": None, "ac": {}, "dc": {}}
                     data["current"] = await self.fetch_current_data(session=session)
 
                     for interval in intervals:
@@ -261,17 +263,20 @@ class Pumpspy:
                     LOG.debug(data)
                     return data
                 except InvalidAccessToken:
+                    retries += 1
+                    LOG.info("Access token expired, refreshing (attempt %s/%s)", retries, max_retries)
                     await self.get_token()
                     await asyncio.sleep(1)  # don't hammer the server
-                    break
 
                 except (
                     aiohttp.ServerDisconnectedError,
                     aiohttp.ClientResponseError,
                     aiohttp.ClientConnectorError,
                 ) as err:
-                    LOG.debug("Oops, the server connection was dropped: %s", err)
+                    retries += 1
+                    LOG.debug("Server connection error: %s (attempt %s/%s)", err, retries, max_retries)
                     await asyncio.sleep(1)  # don't hammer the server
+        raise InvalidAccessToken
 
     async def fetch_current_data(self, session: aiohttp.ClientSession):
         """Get the current data"""

--- a/custom_components/pumpspy_ha/strings.json
+++ b/custom_components/pumpspy_ha/strings.json
@@ -27,6 +27,8 @@
       }
     },
     "error": {
+      "auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "no_locations": "No locations found for this account",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/custom_components/pumpspy_ha/translations/en.json
+++ b/custom_components/pumpspy_ha/translations/en.json
@@ -4,6 +4,8 @@
       "already_configured": "Device is already configured"
     },
     "error": {
+      "auth": "Invalid authentication",
+      "no_locations": "No locations found for this account",
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error"


### PR DESCRIPTION
## Summary

- **config_flow**: Convert `deviceid` to `str` for `unique_id` — HA requires string, API returns int (fixes #18)
- **config_flow**: Add try/except around `pumpspy.setup()` with user-facing error messages instead of unhandled crash (fixes #14, #15)
- **config_flow**: Use user-selected location instead of always using `locations[0]` (fixes #12)
- **pypumpspy**: Retry `fetch_data` with fresh session after token refresh instead of breaking out of loop with empty data
- **__init__**: Raise `UpdateFailed` instead of silently returning `None` from `_async_update_data`, which caused all sensors to crash
- **entity**: Convert `deviceid` to `str` in device identifiers
- Bump version to 0.1.5

## Test plan

- [x] Verify integration setup with valid credentials shows no errors
- [x] Verify integration setup with invalid credentials shows "Invalid authentication" error
- [x] Verify account with multiple locations allows selecting the correct one
- [x] Verify `unique_id` warning no longer appears in HA logs
- [x] Verify sensors recover gracefully after a temporary API outage (UpdateFailed → retry)
- [x] Verify device page shows correct device info with string identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)